### PR TITLE
新增日拱记录时，日期改成日期选择器，默认当天；由于antd判断rowkey的逻辑修改，默认key0会造成判断错误，改为默认-1，后台判断如为-1，修…

### DIFF
--- a/backend/controllers/daily/routine.go
+++ b/backend/controllers/daily/routine.go
@@ -101,8 +101,11 @@ func (c *RoutineController) Get() {
 
 func (c *RoutineController) Post() {
 	info := daily.Routine{}
-	err := json.Unmarshal(c.Ctx.Input.RequestBody, &info)
+	err := json.Unmarshal(c.Ctx.Input.RequestBody, &info)	
 	c.JSONErrorAbort(err)
+    if info.ID == -1 {
+		info.ID = 0
+	}
 
 	err = c.mr.Upsert(&info)
 	c.JSONErrorAbort(err)

--- a/frontend/src/pages/daily/event/edit.tsx
+++ b/frontend/src/pages/daily/event/edit.tsx
@@ -1,12 +1,14 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import type { ProColumns } from '@ant-design/pro-table';
-import { EditableProTable } from '@ant-design/pro-table';
+import { EditableProTable, ActionType } from '@ant-design/pro-table';
 import { RoutineInfo } from './data';
 import { upsertRoutine, deleteRoutine, queryRoutineList } from './service';
+import moment from 'moment';
 
 const EditRoutine = () => {
   const [editableKeys, setEditableRowKeys] = useState<React.Key[]>([]);
   const [dataSource, setDataSource] = useState<RoutineInfo[]>([]);
+  const tableActionRef = useRef<ActionType>();
 
   const columns: ProColumns<RoutineInfo>[] = [
     {
@@ -58,6 +60,7 @@ const EditRoutine = () => {
     },
     {
       title: '开始日期',
+      valueType: 'date',
       dataIndex: 'start_date',
     },
     {
@@ -78,17 +81,19 @@ const EditRoutine = () => {
   ];
 
   return (
+
     <>
       <EditableProTable<RoutineInfo>
+        actionRef={tableActionRef}
         rowKey="id"
         recordCreatorProps={
           {
             position: 'bottom',
             record: {
-              id: 0, icon: '', short_name: '', event_scope: '', will_spend: 0, history_spend: 0,
+              id: -1, icon: '', short_name: '', event_scope: '', will_spend: 0, history_spend: 0,
               today_spend: 0, week_will_spend: 0, week_spend: 0, month_will_spend: 0, month_spend: 0,
               total_will_spend: 0, total_spend: 0,
-              object: 0, object_unit: '', progress: 0, start_date: '',
+              object: 0, object_unit: '', progress: 0, start_date: moment().format("YYYY-MM-DD"),
               week_passed: 0,
             },
           }
@@ -108,6 +113,10 @@ const EditRoutine = () => {
           editableKeys,
           onSave: async (rowKey, data, row) => {
             await upsertRoutine(data);
+            if (tableActionRef.current) {
+              tableActionRef.current.reload();
+            }
+
           },
           onDelete: async (rowKey, data) => {
             await deleteRoutine(data.id);


### PR DESCRIPTION
…改为0，走自增；新增或修改记录后自动刷新页面